### PR TITLE
add missing file-audio-caption.html.twig, adjusted plugins to avoid notice messages

### DIFF
--- a/src/Plugin/search_api/processor/TranscriptSearchIndex.php
+++ b/src/Plugin/search_api/processor/TranscriptSearchIndex.php
@@ -110,6 +110,7 @@ class TranscriptSearchIndex extends ProcessorPluginBase {
    */
   function _parse_transcript_file($file_contents, $drupal_file_uri = '') {
     $transcript_sections = [];
+    $start = $end = $speaker = NULL;
     if (strstr($drupal_file_uri, ".xml")) {
       // XML file -- simple, load the file as simplexml and take appropriate 'cue' section.
       $xml = simplexml_load_string($file_contents, "SimpleXMLElement", LIBXML_NOCDATA);

--- a/src/SearchReindexer.php
+++ b/src/SearchReindexer.php
@@ -43,7 +43,7 @@ class SearchReindexer {
   /**
    * Reindexes parent node for a media. No-op if parent does not exist.
    *
-   * @param Drupal\media\MediaInterface $media
+   * @param \Drupal\media\MediaInterface $media
    *   Media whose parent you want to reindex.
    */
   public function reindexParent(MediaInterface $media) {

--- a/templates/file-audio-caption.html.twig
+++ b/templates/file-audio-caption.html.twig
@@ -1,0 +1,31 @@
+{#
+/**
+* @file
+* Default theme implementation to display the file entity as a video tag.
+*
+* Available variables:
+* - attributes: An array of HTML attributes, intended to be added to the
+*   video tag.
+* - files: And array of files to be added as sources for the video tag. Each
+*   element is an array with the following elements:
+*   - file: The full file object.
+*   - source_attributes: An array of HTML attributes for to be added to the
+*     source tag.
+* - caption: the captions file
+* - poster: the poster (thumbnail) file
+*
+* @ingroup themeable
+*/
+#}
+{% if poster %}
+  <video controls="controls" width="100%" poster="{{ poster }}" crossorigin="anonymous">
+{% else %}
+  <video controls="controls" width="100%" crossorigin="anonymous">
+{% endif %}
+  {% for file in files %}
+    <source {{ file.source_attributes }} />
+  {% endfor %}
+  {% if caption %}
+    <track src="{{ caption }}" kind="captions" crossorigin="anonymous" default>
+  {% endif %}
+</video>


### PR DESCRIPTION
When using the module for audio media, the missing twig template prevented the assumed "Default display" for this media.

The changes fix one error and avoid error notice messages about undefined variables and a \Drupal\media\MediaInterface variable.
